### PR TITLE
Export country and language types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,9 @@ import { Country, countryToCountryMap, MappableCountry } from './countries'
 import { Language, languageToCountryMap, MappableLanguage } from './languages'
 import { CircularGraphic } from './components/CircularGraphic'
 
+export type { Country } from './countries';
+export type { Language } from './languages';
+
 type CircularFlagProps = {
   countryCode: Country
   width: number


### PR DESCRIPTION
typically you have the country/language code stored in a string variable, when using the components you get TypeScript errors.

```ts
const countryCode = "se";
...
<CircleFlag countryCode={countryCode} />
```
> Type 'string' is not assignable to type 'Country'

exposing `Country` and `Language` allows us to cast the variable.